### PR TITLE
Required parameter follows optional parameter causing 500 error in php7.4

### DIFF
--- a/app/Exceptions/FixableInvalidVersionException.php
+++ b/app/Exceptions/FixableInvalidVersionException.php
@@ -8,7 +8,7 @@ class FixableInvalidVersionException extends Exception
 {
     public $redirectTo;
 
-    public function __construct($message, $code = 0, Exception $previous = null, $redirectTo)
+    public function __construct($message, $code = 0, Exception $previous = null, $redirectTo = '/')
     {
         $this->redirectTo = $redirectTo;
 


### PR DESCRIPTION
Adds default value `$redirectTo = '/'` to the FixableInvalidVersionException constructor that was causing a 500 error during testing.

```
  • Tests\Feature\LaravelVersionFromPathTest > more than three segments redirects to three
  Response status code [500] is not a redirect status code.
  Failed asserting that false is true.

  at tests/Feature/LaravelVersionFromPathTest.php:26
     22▕     public function more_than_three_segments_redirects_to_three()
     23▕     {
     24▕         $response = $this->get('/1.1.1.14');
     25▕
  ➜  26▕         $response->assertRedirect('1.1.1');
     27▕     }
     28▕
     29▕     /** @test */
     30▕     public function versions_after_five_dont_require_a_minor()
```