### PR TITLE
Fix inconsistent widths/padding for colorblind mode labels

### DIFF
--- a/resources/views/versions/index.blade.php
+++ b/resources/views/versions/index.blade.php
@@ -101,9 +101,8 @@
                     @endphp
                     @foreach ($activeVersions as $version)
                         <tr>
-                            <th scope="col" class="{{ $statusClassMap[$version->status] }}">
-                                <span class="hidden js-colorblind">{{ $statusTextMap[$version->status] }}</span>
-                                &nbsp;
+                            <th scope="col" class="w-3 {{ $statusClassMap[$version->status] }}">
+                                <span class="hidden js-colorblind mx-2">{{ $statusTextMap[$version->status] }}</span>
                             </th>
                             <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
                                 <a href="{{ $version->url }}" class="underline">{{ $version->major }} {{ $version->released_at->gt(now()) ? '(not released yet!)' : '' }}</a>
@@ -163,9 +162,8 @@
                     <tbody class="bg-white divide-y divide-gray-200">
                     @foreach ($inactiveVersions as $version)
                         <tr>
-                            <th scope="col" class="{{ $statusClassMap[$version->status] }}">
-                                <span class="hidden js-colorblind">{{ $statusTextMap[$version->status] }}</span>
-                                &nbsp;
+                            <th scope="col" class="w-3 {{ $statusClassMap[$version->status] }}">
+                                <span class="hidden js-colorblind mx-2">{{ $statusTextMap[$version->status] }}</span>
                             </th>
                             <td class="px-6 py-4 text-sm font-medium text-gray-900 whitespace-nowrap">
                                 <a href="{{ $version->url }}" class="underline">{{ $version->major }}{{ $version->major < 6 ? '.' . $version->minor : '' }}</a>


### PR DESCRIPTION
Makes the colored tab for each row consistent width between top and bottom tables, and properly centers/pads colorblind labels if enabled.
![image](https://user-images.githubusercontent.com/38962121/106105998-e1c4aa80-6112-11eb-9bc0-032d578539a5.png)
