### PR TITLE
new status future releases

### DIFF
--- a/app/Models/LaravelVersion.php
+++ b/app/Models/LaravelVersion.php
@@ -9,6 +9,7 @@ class LaravelVersion extends Model
 {
     use HasFactory;
 
+    const STATUS_FUTURE = 'future';
     const STATUS_ACTIVE = 'active';
     const STATUS_SECURITY = 'security';
     const STATUS_ENDOFLIFE = 'end-of-life';
@@ -40,7 +41,7 @@ class LaravelVersion extends Model
     {
         // active, security, end-of-life
         if ($this->released_at->gt(now())) {
-            return self::STATUS_ACTIVE;
+            return self::STATUS_FUTURE;
         }
 
         if ($this->ends_bugfixes_at && $this->ends_bugfixes_at->gt(now())) {

--- a/resources/views/versions/index.blade.php
+++ b/resources/views/versions/index.blade.php
@@ -56,6 +56,10 @@
             <div class="hidden float-right font-bold js-colorblind">ALL</div>
             Bug and security fixes
         </div>
+        <div class="p-2 bg-blue-300">
+            <div class="hidden float-right font-bold js-colorblind">FUT</div>
+            Future release
+        </div>
     </div>
 
     <p class="mb-8 3xl clear" style="clear: both">To learn more about Laravel's versioning strategy, check out the <a href="https://laravel-news.com/laravel-releases" class="text-blue-800 underline hover:text-blue-600">Laravel News "Laravel Releases" page</a>.</p>
@@ -89,11 +93,13 @@
                     <tbody class="bg-white divide-y divide-gray-200">
                     @php
                         $statusClassMap = [
+                            App\Models\LaravelVersion::STATUS_FUTURE => 'bg-blue-300',
                             App\Models\LaravelVersion::STATUS_ACTIVE => 'bg-green-300',
                             App\Models\LaravelVersion::STATUS_SECURITY => 'bg-yellow-300',
                             App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'bg-red-300',
                         ];
                         $statusTextMap = [
+                            App\Models\LaravelVersion::STATUS_FUTURE => 'FUT',
                             App\Models\LaravelVersion::STATUS_ACTIVE => 'ALL',
                             App\Models\LaravelVersion::STATUS_SECURITY => 'SEC',
                             App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'EOL',

--- a/resources/views/versions/show.blade.php
+++ b/resources/views/versions/show.blade.php
@@ -29,6 +29,9 @@
                         Keep patch updated.
                     @elseif ($version->status == App\Models\LaravelVersion::STATUS_SECURITY)
                         Update to the latest major or LTS release.
+                    @elseif ($version->status == App\Models\LaravelVersion::STATUS_FUTURE)
+                        This version of the release is planned only and <strong>not released yet!</strong><br>
+                        The estimated release date is {{ $version->released_at->format('F Y') }}
                     @else
                         @php
                             $recommendation = (new App\LowestSupportedVersion)($version);

--- a/resources/views/versions/show.blade.php
+++ b/resources/views/versions/show.blade.php
@@ -7,12 +7,14 @@
             <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
             @php
                 $statusText = [
+                    App\Models\LaravelVersion::STATUS_FUTURE => 'Future release',
                     App\Models\LaravelVersion::STATUS_ACTIVE => 'Active support',
                     App\Models\LaravelVersion::STATUS_SECURITY => 'Security fixes only',
                     App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'Not receiving bug or security fixes',
                 ];
 
                 $recommendationText = [
+                    App\Models\LaravelVersion::STATUS_FUTURE => 'Planned release.',
                     App\Models\LaravelVersion::STATUS_ACTIVE => 'Keep patch updated.',
                     App\Models\LaravelVersion::STATUS_SECURITY => 'Update to the latest major or LTS release.',
                     App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>',
@@ -64,11 +66,13 @@
                     <tbody class="bg-white divide-y divide-gray-200">
                     @php
                         $statusClassMap = [
+                            App\Models\LaravelVersion::STATUS_FUTURE => 'bg-blue-300',
                             App\Models\LaravelVersion::STATUS_ACTIVE => 'bg-green-300',
                             App\Models\LaravelVersion::STATUS_SECURITY => 'bg-yellow-300',
                             App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'bg-red-300',
                         ];
                         $statusTextMap = [
+                            App\Models\LaravelVersion::STATUS_FUTURE => 'FUT',
                             App\Models\LaravelVersion::STATUS_ACTIVE => 'ALL',
                             App\Models\LaravelVersion::STATUS_SECURITY => 'SEC',
                             App\Models\LaravelVersion::STATUS_ENDOFLIFE => 'EOL',


### PR DESCRIPTION
As I mentioned on Twitter <blockquote class="twitter-tweet"><p lang="en" dir="ltr">great tool on the site but I have some &quot;but&quot; the color of unreleased versions i.e. future releases should not be green but blue as is often used in <a href="https://twitter.com/hashtag/php?src=hash&amp;ref_src=twsrc%5Etfw">#php</a> and <a href="https://twitter.com/Wikimedia?ref_src=twsrc%5Etfw">@Wikimedia</a></p>&mdash; Olsza (@czlowiek_it) <a href="https://twitter.com/czlowiek_it/status/1354527441428094980?ref_src=twsrc%5Etfw">January 27, 2021</a></blockquote> 

My PR already includes it :)

![future](https://user-images.githubusercontent.com/12556170/106216158-c9b46000-61d2-11eb-8c49-6606e0de8e46.png)
![info-future](https://user-images.githubusercontent.com/12556170/106216157-c91bc980-61d2-11eb-8146-abc79101a8fb.png)

