### PR TITLE
Fail if "lowest supported version" can't be found

### DIFF
--- a/app/LowestSupportedVersion.php
+++ b/app/LowestSupportedVersion.php
@@ -15,6 +15,6 @@ class LowestSupportedVersion
             $query->where('major', '>', $greaterThanVersion->major);
         }
 
-        return $query->first();
+        return $query->firstOrFail();
     }
 }

--- a/database/factories/LaravelVersionFactory.php
+++ b/database/factories/LaravelVersionFactory.php
@@ -23,4 +23,17 @@ class LaravelVersionFactory extends Factory
             'ends_securityfixes_at' => $released_at->clone()->addYears(2),
         ];
     }
+
+    public function active()
+    {
+        return $this->state(function (array $attributes) {
+            $futureDate = now()->addYear(1);
+
+            return [
+                'major' => 99999,
+                'ends_bugfixes_at' => $futureDate,
+                'ends_securityfixes_at' => $futureDate,
+            ];
+        });
+    }
 }

--- a/resources/views/partials/modules/show_recommendations.blade.php
+++ b/resources/views/partials/modules/show_recommendations.blade.php
@@ -20,6 +20,7 @@
                 'link-laravelshifts' => '<a href="https://laravelshift.com/shifts?version=' . $version->majorish . '" class="border-hover">Laravel Shift</a>'
                 ])
             !!}
+            
         @endif
     </p>
     <div class="mb-16 lg:mb-24">

--- a/tests/Feature/ShowVersionTest.php
+++ b/tests/Feature/ShowVersionTest.php
@@ -22,8 +22,10 @@ class ShowVersionTest extends TestCase
     }
 
     /** @test */
-    public function it_loads_is_not_date_in_ends_bugfixes_at()
+    public function it_loads_when_bug_fixes_date_is_null()
     {
+        $this->seedLowestSupportedVersion();
+
         $version = LaravelVersion::factory()->create([
             'ends_bugfixes_at' => null,
         ]);
@@ -33,13 +35,20 @@ class ShowVersionTest extends TestCase
     }
 
     /** @test */
-    public function it_loads_is_not_date_in_ends_securityfixes_at()
+    public function it_loads_when_security_fixes_date_is_null()
     {
+        $this->seedLowestSupportedVersion();
+
         $version = LaravelVersion::factory()->create([
             'ends_securityfixes_at' => null,
         ]);
         $response = $this->get(route('versions.show', [$version->__toString()]));
 
         $response->assertStatus(200);
+    }
+
+    private function seedLowestSupportedVersion()
+    {
+        LaravelVersion::factory()->active()->create();
     }
 }


### PR DESCRIPTION
- add "active" state to version factory
- rename some tests
- seed lowest supported version for tests that may occasionally need it

Closes #51

Co-Authored-By: Matt Stauffer <mattstauffer@users.noreply.github.com>