### PR TITLE
Fix missing logo on firefox

### DIFF
--- a/resources/views/partials/modules/header.blade.php
+++ b/resources/views/partials/modules/header.blade.php
@@ -2,11 +2,11 @@
     <div class="flex flex-col max-w-screen-xl px-4 mx-auto sm:items-center sm:justify-between sm:flex-row-reverse sm:px-6 lg:px-8">
 
         @if (Config::has('localized-routes.supported-locales'))
-            <x-language-selector /> 
+            <x-language-selector />
         @endif
 
         <div class="mb-2 text-3xl">
-            <a href="{{ route('versions.index') }}" class="inline-block"><img class="w-full h-full" src="/svg/logo.svg" alt="Laravel Versions Logo"></a>
+            <a href="{{ route('versions.index') }}" class="inline-block"><img class="w-full h-full" src="/svg/logo.svg" style="width: 295px;" alt="Laravel Versions Logo"></a>
         </div>
     </div>
     <div class="{{ Route::is('*.versions.index') ? 'max-w-screen-xl px-4 py-4 mx-auto text-base text-white sm:px-6 lg:px-8' : 'hidden' }}">


### PR DESCRIPTION
Fixed missing logo on firefox

Before this fix:
![firefox_zHvfSkBjw5](https://user-images.githubusercontent.com/4071613/112545720-d90def00-8db8-11eb-96cf-bbc96a659b29.png)

After this fix:
![firefox_SVGwjEPCuU](https://user-images.githubusercontent.com/4071613/112545760-e1fec080-8db8-11eb-9061-d7f032fcfa9a.png)
