### PR TITLE
[Proposal] Add latest release to version response

### DIFF
--- a/app/Http/Resources/LaravelVersionResource.php
+++ b/app/Http/Resources/LaravelVersionResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Models\LaravelVersion;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -17,6 +18,7 @@ class LaravelVersionResource extends JsonResource
             $minor_label => $this->minor,
             'latest_patch' => $this->patch,
             'latest' => sprintf('%s.%s.%s', $this->major, $this->minor, $this->patch),
+            'latest_major' => (string) LaravelVersion::released()->orderByDesc('major')->orderByDesc('minor')->orderByDesc('patch')->first(),
             'is_lts' => $this->is_lts,
             'released_at' => $this->released_at,
             'ends_bugfixes_at' => $this->ends_bugfixes_at,

--- a/app/Http/Resources/LaravelVersionResource.php
+++ b/app/Http/Resources/LaravelVersionResource.php
@@ -18,7 +18,7 @@ class LaravelVersionResource extends JsonResource
             $minor_label => $this->minor,
             'latest_patch' => $this->patch,
             'latest' => sprintf('%s.%s.%s', $this->major, $this->minor, $this->patch),
-            'latest_major' => (string) LaravelVersion::released()->orderByDesc('major')->orderByDesc('minor')->orderByDesc('patch')->first(),
+            'latest_release' => (string) LaravelVersion::released()->orderByDesc('major')->orderByDesc('minor')->orderByDesc('patch')->first(),
             'is_lts' => $this->is_lts,
             'released_at' => $this->released_at,
             'ends_bugfixes_at' => $this->ends_bugfixes_at,

--- a/app/Http/Resources/LaravelVersionResource.php
+++ b/app/Http/Resources/LaravelVersionResource.php
@@ -12,13 +12,13 @@ class LaravelVersionResource extends JsonResource
     {
         $minor_label = $this->major < 6 ? 'minor' : 'latest_minor';
         $segments = $request->segments();
+        $latest_version = LaravelVersion::released()->orderByDesc('major')->orderByDesc('minor')->orderByDesc('patch')->first();
 
         return [
             'major' => $this->major,
             $minor_label => $this->minor,
             'latest_patch' => $this->patch,
             'latest' => sprintf('%s.%s.%s', $this->major, $this->minor, $this->patch),
-            'latest_release' => (string) LaravelVersion::released()->orderByDesc('major')->orderByDesc('minor')->orderByDesc('patch')->first(),
             'is_lts' => $this->is_lts,
             'released_at' => $this->released_at,
             'ends_bugfixes_at' => $this->ends_bugfixes_at,
@@ -32,6 +32,10 @@ class LaravelVersionResource extends JsonResource
                 ],
             ]),
             'links' => $this->links($request),
+            'global' => [
+                'latest_version' => (string) $latest_version,
+                'latest_version_is_lts' => $latest_version->is_lts,
+            ],
         ];
     }
 

--- a/tests/Feature/ApiShowVersionTest.php
+++ b/tests/Feature/ApiShowVersionTest.php
@@ -40,7 +40,7 @@ class ApiShowVersionTest extends TestCase
 
         $this->getJson(route('api.versions.show', [$oldest->__toString()]))
             ->assertJsonFragment([
-                'latest_major' => $newest->__toString(),
+                'latest_release' => $newest->__toString(),
         ]);
     }
 }

--- a/tests/Feature/ApiShowVersionTest.php
+++ b/tests/Feature/ApiShowVersionTest.php
@@ -18,4 +18,29 @@ class ApiShowVersionTest extends TestCase
 
         $response->assertStatus(200);
     }
+
+    /** @test */
+    public function it_loads_latest_version()
+    {
+        $newest = LaravelVersion::factory()->create([
+            'major' => 8,
+        ]);
+
+        // older patch
+        LaravelVersion::factory()->create([
+            'major' => $newest->major,
+            'minor' => $newest->minor,
+            'patch' => $newest->minor - 1,
+        ]);
+
+        //older major version
+        $oldest = LaravelVersion::factory()->create([
+            'major' => $newest->major - 1,
+        ]);
+
+        $this->getJson(route('api.versions.show', [$oldest->__toString()]))
+            ->assertJsonFragment([
+                'latest_major' => $newest->__toString(),
+        ]);
+    }
 }

--- a/tests/Feature/ApiShowVersionTest.php
+++ b/tests/Feature/ApiShowVersionTest.php
@@ -24,6 +24,7 @@ class ApiShowVersionTest extends TestCase
     {
         $newest = LaravelVersion::factory()->create([
             'major' => 8,
+            'is_lts' => false,
         ]);
 
         // older patch
@@ -40,7 +41,8 @@ class ApiShowVersionTest extends TestCase
 
         $this->getJson(route('api.versions.show', [$oldest->__toString()]))
             ->assertJsonFragment([
-                'latest_release' => $newest->__toString(),
+                'latest_version' => $newest->__toString(),
+                'latest_version_is_lts' => false,
         ]);
     }
 }


### PR DESCRIPTION
Adds a string version of the latest Laravel release to the json returned from `api/versions` endpoints as `latest_release`. 

We currently have the `status` being returned, as well as the `latest` minor/patch version, but adding the most recent release (regardless of major version) might help API consumers provide recommendations for major versions that are end-of-life.

**New example response**
<img width="622" alt="Screen Shot 2021-09-09 at 3 16 39 PM" src="https://user-images.githubusercontent.com/4378273/132750881-4d391e12-0f74-4e14-bf03-6126487ba1d3.png">
