### PR TITLE
Add link to PHP supported versions to home page

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1,4 +1,5 @@
 {
+    "A list of currently supported PHP versions can be found here: :link": "A list of currently supported PHP versions can be found here: :link",
     "Active support": "Active support",
     "Brought to you by the lovely folks at": "Brought to you by the lovely folks at",
     "Bug & security fixes": "Bug & security fixes",
@@ -42,6 +43,5 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>",
     "Update to the latest major or LTS release.": "Update to the latest major or LTS release.",
     "Version": "Version",
-    "You can also find a list of all of the security advisories for Laravel here: :link": "You can also find a list of all of the security advisories for Laravel here: :link",
-    "A list of currently supported PHP versions can be found here: :link": "A list of currently supported PHP versions can be found here: :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link": "You can also find a list of all of the security advisories for Laravel here: :link"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -42,5 +42,6 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>",
     "Update to the latest major or LTS release.": "Update to the latest major or LTS release.",
     "Version": "Version",
-    "You can also find a list of all of the security advisories for Laravel here: :link": "You can also find a list of all of the security advisories for Laravel here: :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link": "You can also find a list of all of the security advisories for Laravel here: :link",
+    "A list of currently supported PHP versions can be found here: :link": "A list of currently supported PHP versions can be found here: :link"
 }

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -43,5 +43,5 @@
     "Update to the latest major or LTS release.": "Zaktualizuj do najnowszej wersji głównej (major) lub do wersji LTS.",
     "Version": "Wersja",
     "You can also find a list of all of the security advisories for Laravel here: :link": "Listę wszystkich poradników bezpieczeństwa dla Laravela znajdziesz na: :link",
-    "A list of currently supported PHP versions can be found here: :link": "Listę aktualnie obsługiwanych wersji PHP można znaleźć na: :link"
+    "A list of currently supported PHP versions can be found here: :link": "Aktualna lista obsługiwanych wersji PHP można znaleźć na: :link"
 }

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -42,5 +42,6 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Zaktualizuj <em>co najmniej</em> do wersji z zachowanymi zabezpieczeniami <strong>tak szybko, jak to możliwe!</strong>",
     "Update to the latest major or LTS release.": "Zaktualizuj do najnowszej wersji głównej (major) lub do wersji LTS.",
     "Version": "Wersja",
-    "You can also find a list of all of the security advisories for Laravel here: :link": "Listę wszystkich poradników bezpieczeństwa dla Laravela znajdziesz na: :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link": "Listę wszystkich poradników bezpieczeństwa dla Laravela znajdziesz na: :link",
+    "A list of currently supported PHP versions can be found here: :link": "Listę aktualnie obsługiwanych wersji PHP można znaleźć na: :link"
 }

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -1,4 +1,5 @@
 {
+    "A list of currently supported PHP versions can be found here: :link": "Aktualna lista obsługiwanych wersji PHP można znaleźć na: :link",
     "Active support": "Aktywne wsparcie",
     "Brought to you by the lovely folks at": "Dostarczone przezuroczych ludzi w",
     "Bug & security fixes": "Poprawki błędów i bezpieczeństwa",
@@ -42,6 +43,5 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Zaktualizuj <em>co najmniej</em> do wersji z zachowanymi zabezpieczeniami <strong>tak szybko, jak to możliwe!</strong>",
     "Update to the latest major or LTS release.": "Zaktualizuj do najnowszej wersji głównej (major) lub do wersji LTS.",
     "Version": "Wersja",
-    "You can also find a list of all of the security advisories for Laravel here: :link": "Listę wszystkich poradników bezpieczeństwa dla Laravela znajdziesz na: :link",
-    "A list of currently supported PHP versions can be found here: :link": "Aktualna lista obsługiwanych wersji PHP można znaleźć na: :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link": "Listę wszystkich poradników bezpieczeństwa dla Laravela znajdziesz na: :link"
 }

--- a/resources/lang/sw.json
+++ b/resources/lang/sw.json
@@ -1,4 +1,5 @@
 {
+    "A list of currently supported PHP versions can be found here: :link": "Orodha ya matoleo ya PHP yanayotumika sasa yanaweza kupatikana hapa: :link",
     "Active support":"Msaada wa kazi",
     "Brought to you by the lovely folks at":"Kuletwa kwako na watu wazuri huko",
     "Bug & security fixes":"Marekebisho ya hitilafu na usalama",
@@ -42,6 +43,5 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Sasisha <em>angalau</em> toleo linalodumishwa kwa usalama  <strong>haraka iwezekanavyo!</strong>",
     "Update to the latest major or LTS release.": "Sasisha kutolewa kwa hivi karibuni kuu au LTS.",
     "Version": "Toleo",
-    "You can also find a list of all of the security advisories for Laravel here: :link":"Unaweza pia kupata orodha ya mashauri yote ya usalama ya Laravel hapa: :link",
-    "A list of currently supported PHP versions can be found here: :link": "Orodha ya matoleo ya PHP yanayotumika sasa yanaweza kupatikana hapa: :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link":"Unaweza pia kupata orodha ya mashauri yote ya usalama ya Laravel hapa: :link"
 }

--- a/resources/lang/sw.json
+++ b/resources/lang/sw.json
@@ -42,5 +42,6 @@
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Sasisha <em>angalau</em> toleo linalodumishwa kwa usalama  <strong>haraka iwezekanavyo!</strong>",
     "Update to the latest major or LTS release.": "Sasisha kutolewa kwa hivi karibuni kuu au LTS.",
     "Version": "Toleo",
-    "You can also find a list of all of the security advisories for Laravel here: :link":"Unaweza pia kupata orodha ya mashauri yote ya usalama ya Laravel hapa :link"
+    "You can also find a list of all of the security advisories for Laravel here: :link":"Unaweza pia kupata orodha ya mashauri yote ya usalama ya Laravel hapa: :link",
+    "A list of currently supported PHP versions can be found here: :link": "Orodha ya matoleo ya PHP yanayotumika sasa yanaweza kupatikana hapa: :link"
 }

--- a/resources/views/versions/index.blade.php
+++ b/resources/views/versions/index.blade.php
@@ -24,4 +24,11 @@
             ]);
         !!}
     </div>
+
+    <div class="mt-6 text-center">
+        {!! __('A list of currently supported PHP versions can be found here: :link', [
+                'link' => '<a class="text-blue-600 underline" href="https://www.php.net/supported-versions.php">https://www.php.net/supported-versions.php</a>'
+            ]);
+        !!}
+    </div>
 </x-app-layout>


### PR DESCRIPTION
This PR is meant to at least start work around closing #39 
I can update the link to match any design or location suggestions.


- [ ] de.json
- [x] en.json
- [ ] es.json
- [ ] fr.json
- [ ] id.json
- [ ] it.json
- [ ] ja.json
- [ ] lt.json
- [x] pl.json
- [ ] pt_BR.json
- [ ] ru.json
- [x] sw.json
- [ ] uk.json
- [ ] vi.json
- [ ] zh_CN.json


I used Google Translate to update the language files:

- [Polish](https://translate.google.com/?sl=pl&tl=en&text=List%C4%99%20aktualnie%20obs%C5%82ugiwanych%20wersji%20PHP%20mo%C5%BCna%20znale%C5%BA%C4%87%20na&op=translate&hl=en)
- [Swahili](https://translate.google.com/?hl=en&sl=sw&tl=en&text=Orodha%20ya%20matoleo%20ya%20PHP%20yanayotumika%20sasa%20yanaweza%20kupatikana%20hapa&op=translate)

![Screen Shot 2021-09-17 at 11 23 08 AM](https://user-images.githubusercontent.com/194221/133837529-a58965ef-c2f6-443e-af92-44fc806273c0.png)


