### PR TITLE
Fix tweet scheduling

### DIFF
--- a/app/Models/LaravelVersion.php
+++ b/app/Models/LaravelVersion.php
@@ -27,8 +27,8 @@ class LaravelVersion extends Model
     {
         return [
             'today' => now()->startOfDay(),
-            'tomorrow' => now()->subDay()->startOfDay(),
-            'in one week' => now()->subWeek()->startOfDay(),
+            'tomorrow' => now()->addDay()->startOfDay(),
+            'in one week' => now()->addWeek()->startOfDay(),
         ];
     }
 

--- a/tests/Feature/TweetImportantDatesTest.php
+++ b/tests/Feature/TweetImportantDatesTest.php
@@ -26,7 +26,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving security fixes today.");
         });
     }
 
@@ -42,7 +42,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving security fixes tomorrow.");
         });
     }
 
@@ -58,7 +58,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving security fixes in one week.");
         });
     }
 
@@ -74,7 +74,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving bug fixes today.");
         });
     }
 
@@ -90,7 +90,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving bug fixes tomorrow.");
         });
     }
 
@@ -106,7 +106,7 @@ class TweetImportantDatesTest extends TestCase
         Artisan::call('tweet-important-dates');
 
         Http::assertSent(function (Request $request) use ($version) {
-            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+            return Str::contains($request['text'], "Laravel version {$version->major} will stop receiving bug fixes in one week.");
         });
     }
 }

--- a/tests/Feature/TweetImportantDatesTest.php
+++ b/tests/Feature/TweetImportantDatesTest.php
@@ -31,12 +31,76 @@ class TweetImportantDatesTest extends TestCase
     }
 
     /** @test */
+    public function it_tweets_the_day_before_security_fixes_end()
+    {
+        Http::fake();
+
+        $version = LaravelVersion::factory()->create([
+            'ends_securityfixes_at' => now()->addDay()->startOfDay(),
+        ]);
+
+        Artisan::call('tweet-important-dates');
+
+        Http::assertSent(function (Request $request) use ($version) {
+            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+        });
+    }
+
+    /** @test */
+    public function it_tweets_the_week_before_security_fixes_end()
+    {
+        Http::fake();
+
+        $version = LaravelVersion::factory()->create([
+            'ends_securityfixes_at' => now()->addWeek()->startOfDay(),
+        ]);
+
+        Artisan::call('tweet-important-dates');
+
+        Http::assertSent(function (Request $request) use ($version) {
+            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+        });
+    }
+
+    /** @test */
     public function it_tweets_on_the_day_bug_fixes_end()
     {
         Http::fake();
 
         $version = LaravelVersion::factory()->create([
             'ends_bugfixes_at' => now()->startOfDay(),
+        ]);
+
+        Artisan::call('tweet-important-dates');
+
+        Http::assertSent(function (Request $request) use ($version) {
+            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+        });
+    }
+
+    /** @test */
+    public function it_tweets_the_day_before_bug_fixes_end()
+    {
+        Http::fake();
+
+        $version = LaravelVersion::factory()->create([
+            'ends_bugfixes_at' => now()->addDay()->startOfDay(),
+        ]);
+
+        Artisan::call('tweet-important-dates');
+
+        Http::assertSent(function (Request $request) use ($version) {
+            return Str::contains($request['text'], 'Laravel version ' . $version->major);
+        });
+    }
+
+    /** @test */
+    public function it_tweets_the_week_before_bug_fixes_end()
+    {
+        Http::fake();
+
+        $version = LaravelVersion::factory()->create([
+            'ends_bugfixes_at' => now()->addWeek()->startOfDay(),
         ]);
 
         Artisan::call('tweet-important-dates');


### PR DESCRIPTION
This PR fixes an issue with the scheduling of warning tweets for 'one week' and 'tomorrow'.

The order of tweets should be reversed:
<img width="543" alt="Screenshot 2023-01-06 at 9 58 11 AM" src="https://user-images.githubusercontent.com/194221/211070861-f387da53-7f9f-416c-94af-c2827a91b1bd.png">

Closes #120 