### PR TITLE
Update views to use quarters for future releases

### DIFF
--- a/resources/views/partials/modules/show_recommendations.blade.php
+++ b/resources/views/partials/modules/show_recommendations.blade.php
@@ -7,7 +7,7 @@
             {{ __('Update to the latest major or LTS release.') }}
         @elseif ($version->status == App\Models\LaravelVersion::STATUS_FUTURE)
             {!! __('This version of the release is planned only and <strong>not released yet!</strong>') !!}<br>
-            {{ __('The estimated release date is :date', ['date' => $version->released_at->translatedFormat(__('DateMonthYear'))]) }}
+            {{ __('The estimated release date is :date', ['date' => 'Q' . $version->released_at->quarter . ' ' . $version->released_at->year]) }}
         @else
             @php
                 $recommendation = (new App\LowestSupportedVersion)($version);

--- a/resources/views/partials/tables/current_table.blade.php
+++ b/resources/views/partials/tables/current_table.blade.php
@@ -31,38 +31,29 @@
                         <tr>
                             <th class="px-6 py-4 text-sm font-medium text-left text-gray-900 whitespace-nowrap">
                                 <a href="{{ $version->url }}" class="border-hover">{{ $version->major }} {{
-                                    $version->released_at->gt(now())
+                                    $version->released_at?->gt(now())
                                         ? '(' . __('not released yet!') . ')'
                                         : ''
                                 }}</a>
                             </th>
                             <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
-                                {{ $version->released_at->translatedFormat(__('DateLongFormat')) }}
-                                {{--
-                                    Retaining this in case we go back to non-specific future release dates.
-                                    $version->released_at->gt(now())
-                                        ? $version->released_at->translatedFormat(__('DateShortFormat')) . ' (' . __('estimated') . ')'
-                                        : $version->released_at->translatedFormat(__('DateLongFormat'))
-                                --}}
+                                   {{ $version->released_at->gt(now())
+                                        ? 'Q' . $version->released_at->quarter . ' ' . $version->released_at->year . ' (' . __('estimated') . ')'
+                                        : $version->released_at->translatedFormat(__('DateLongFormat')) }}
+
                             </td>
                             <td class="py-4 pl-6 text-sm text-gray-500 lg:pl-8 whitespace-nowrap">
                                 @if ($version->ends_bugfixes_at)
-                                {{ $version->ends_bugfixes_at->translatedFormat(__('DateLongFormat')) }}
-                                {{--
-                                        $version->released_at->gt(now())
-                                            ? $version->ends_bugfixes_at->translatedFormat(__('DateShortFormat')) . ' (' . __('estimated') . ')'
-                                            : $version->ends_bugfixes_at->translatedFormat(__('DateLongFormat'))
-                                    --}}
+                                {{ $version->released_at->gt(now())
+                                    ? 'Q' . $version->ends_bugfixes_at->quarter . ' ' . $version->ends_bugfixes_at->year . ' (' . __('estimated') . ')'
+                                    : $version->ends_bugfixes_at->translatedFormat(__('DateLongFormat')) }}
                                 @endif
                             </td>
                             <td class="py-4 pl-6 text-sm text-gray-500 lg:pl-8 whitespace-nowrap">
                                 @if ($version->ends_securityfixes_at)
-                                {{ $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat')) }}
-                                {{--
-                                        $version->released_at->gt(now())
-                                            ? $version->ends_securityfixes_at->translatedFormat(__('DateShortFormat')) . ' (' . __('estimated') . ')'
-                                            : $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat'))
-                                    --}}
+                                {{ $version->released_at->gt(now())
+                                    ? 'Q' . $version->ends_securityfixes_at->quarter . ' ' . $version->ends_securityfixes_at->year . ' (' . __('estimated') . ')'
+                                    : $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat')) }}
                                 @endif
                             </td>
                             <td class="py-4 pl-6 text-sm text-gray-500 lg:pl-8 whitespace-nowrap">

--- a/resources/views/partials/tables/show_table.blade.php
+++ b/resources/views/partials/tables/show_table.blade.php
@@ -54,7 +54,7 @@
                     <td class="px-6 py-4 text-sm text-gray-500 whitespace-nowrap">
                         {{
                             $version->released_at->gt(now())
-                                ? $version->released_at->translatedFormat(__('DateLongFormat')) . ' (' . __('estimated') . ')'
+                                ? 'Q' . $version->released_at->quarter . ' ' . $version->released_at->year . ' (' . __('estimated') . ')'
                                 : $version->released_at->translatedFormat(__('DateLongFormat'))
                         }}
                     </td>
@@ -63,7 +63,7 @@
                             $version->ends_bugfixes_at
                                 ? (
                                     $version->released_at->gt(now())
-                                        ? $version->ends_bugfixes_at->translatedFormat(__('DateShortFormat')) . ' (' . __('estimated') . ')'
+                                        ? 'Q' . $version->ends_bugfixes_at->quarter . ' ' . $version->ends_bugfixes_at->year . ' (' . __('estimated') . ')'
                                         : $version->ends_bugfixes_at->translatedFormat(__('DateLongFormat'))
                                 )
                                 : ''
@@ -74,7 +74,7 @@
                             $version->ends_securityfixes_at
                                 ? (
                                     $version->released_at->gt(now())
-                                        ? $version->ends_securityfixes_at->translatedFormat(__('DateShortFormat')) . ' (' . __('estimated') . ')'
+                                        ? 'Q' . $version->ends_securityfixes_at->quarter . ' ' . $version->ends_securityfixes_at->year . ' (' . __('estimated') . ')'
                                         : $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat'))
                                 )
                                 : ''


### PR DESCRIPTION
This PR updates the views to use quarters (Q1) for future releases.

<img width="1241" alt="Screenshot 2023-02-06 at 8 34 09 AM" src="https://user-images.githubusercontent.com/194221/217031431-79a653a1-61b7-49c9-b255-7fe9ed5b1630.png">

<img width="1243" alt="Screenshot 2023-02-06 at 8 40 28 AM" src="https://user-images.githubusercontent.com/194221/217031442-cc8a6cb1-dd22-4f83-a099-503d6e1d196d.png">
