### PR TITLE
Remove concept of LTS from UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ https://laravelversions.com/api/versions
       "latest_minor":47,
       "latest_patch":0,
       "latest":"9.47.0",
-      "is_lts":false,
       "released_at":"2022-02-08T00:00:00.000000Z",
       "ends_bugfixes_at":"2023-08-08T00:00:00.000000Z",
       "ends_securityfixes_at":"2024-02-08T00:00:00.000000Z",
@@ -36,7 +35,6 @@ https://laravelversions.com/api/versions
       ],
       "global":{
         "latest_version":"9.47.0",
-        "latest_version_is_lts":false
       }
     },
     {}
@@ -61,7 +59,6 @@ If you request a minor/patch version (e.g. `/8.1` or `/8.1.0`) you'll see an add
         "latest_minor": 24,
         "latest_patch": 0,
         "latest": "8.24.0",
-        "is_lts": false,
         "released_at": "2020-09-08T00:00:00.000000Z",
         "ends_bugfixes_at": "2021-04-21T00:00:00.000000Z",
         "ends_securityfixes_at": "2021-09-08T00:00:00.000000Z",

--- a/app/Http/Resources/LaravelVersionResource.php
+++ b/app/Http/Resources/LaravelVersionResource.php
@@ -18,7 +18,6 @@ class LaravelVersionResource extends JsonResource
             $minor_label => $this->last->minor,
             'latest_patch' => $this->last->patch,
             'latest' => $this->last->semver,
-            'is_lts' => $this->is_lts,
             'released_at' => $this->released_at,
             'ends_bugfixes_at' => $this->ends_bugfixes_at,
             'ends_securityfixes_at' => $this->ends_securityfixes_at,
@@ -33,7 +32,6 @@ class LaravelVersionResource extends JsonResource
             'links' => $this->links($request),
             'global' => [
                 'latest_version' => (string) $latest_version,
-                'latest_version_is_lts' => $latest_version->is_lts,
             ],
         ];
     }

--- a/app/Models/LaravelVersion.php
+++ b/app/Models/LaravelVersion.php
@@ -27,7 +27,6 @@ class LaravelVersion extends Model
         'released_at' => 'date',
         'ends_bugfixes_at' => 'date',
         'ends_securityfixes_at' => 'date',
-        'is_lts' => 'bool',
     ];
 
     public static function notificationDays()

--- a/database/factories/LaravelVersionFactory.php
+++ b/database/factories/LaravelVersionFactory.php
@@ -19,7 +19,6 @@ class LaravelVersionFactory extends Factory
             'major' => $semver->major,
             'minor' => $semver->minor,
             'patch' => $semver->patch,
-            'is_lts' => false,
             'changelog' => null,
             'released_at' => $released_at,
             'ends_bugfixes_at' => $released_at->clone()->addYear(),

--- a/database/migrations/2023_04_18_203851_drop_column_is_lts.php
+++ b/database/migrations/2023_04_18_203851_drop_column_is_lts.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('laravel_versions', function (Blueprint $table) {
+            $table->dropColumn('is_lts');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('laravel_versions', function (Blueprint $table) {
+            $table->boolean('is_lts')->default(false);
+        });
+    }
+};

--- a/database/seeders/LaravelVersionSeeder.php
+++ b/database/seeders/LaravelVersionSeeder.php
@@ -47,7 +47,6 @@ class LaravelVersionSeeder extends Seeder
                 'released_at' => '2019-09-03',
                 'ends_bugfixes_at' => '2021-09-07',
                 'ends_securityfixes_at' => '2022-09-06',
-                'is_lts' => true,
             ],
             [
                 'major' => 5,
@@ -76,7 +75,6 @@ class LaravelVersionSeeder extends Seeder
                 'released_at' => '2017-08-30',
                 'ends_bugfixes_at' => '2019-08-30',
                 'ends_securityfixes_at' => '2020-08-30',
-                'is_lts' => true,
             ],
             [
                 'major' => 5,
@@ -105,7 +103,6 @@ class LaravelVersionSeeder extends Seeder
                 'released_at' => '2015-06-09',
                 'ends_bugfixes_at' => '2017-06-09',
                 'ends_securityfixes_at' => '2018-06-09',
-                'is_lts' => true,
             ],
             [
                 'major' => 5,

--- a/lang/en.json
+++ b/lang/en.json
@@ -41,7 +41,7 @@
     "To learn more about Laravel's versioning strategy, check out the :link.": "To learn more about Laravel's versioning strategy, check out the :link.",
     "To upgrade, follow the instructions in the docs or use :link-laravelshifts to upgrade automatically.": "To upgrade, follow the instructions in the docs or use :link-laravelshifts to upgrade automatically.",
     "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>": "Update <em>at least</em> to a security-maintained version <strong>as soon as possible!</strong>",
-    "Update to the latest major or LTS release.": "Update to the latest major or LTS release.",
+    "Update to the latest major or LTS release.": "Update to the latest major.",
     "Version": "Version",
     "You can also find a list of all of the security advisories for Laravel here: :link": "You can also find a list of all of the security advisories for Laravel here: :link"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -20,7 +20,6 @@
     "Laravel Version": "Version de Laravel",
     "Laravel Versions": "Versions de Laravel",
     "Latest Patch Release": "Dernier Correctif Publié",
-    "LTS?": "LTS ?",
     "Major Version": "Version Majeure",
     "Need help upgrading your app? Try :link-laravelshift for automated upgrades or :link-tighten if you need more than just upgrades.": "Besoin d'aide pour mettre à jour votre application ? Essayez :link-laravelshift pour les mises à niveau automatisées ou :link-tighten si vous avez besoin de plus que de simples mises à niveau.",
     "No longer receiving security updates!": "Ne reçoivent plus de mises à jour de sécurité !",

--- a/resources/views/partials/tables/current_table.blade.php
+++ b/resources/views/partials/tables/current_table.blade.php
@@ -18,9 +18,6 @@
                             <th scope="col" class="py-3 pl-6 font-medium tracking-wider text-left text-gray-500 uppercase lg:pl-8">
                                 {{ __('Security Fixes Until') }}
                             </th>
-                            <th scope="col" class="py-3 pl-6 font-medium tracking-wider text-left text-gray-500 uppercase">
-                                {{ __('LTS?') }}
-                            </th>
                             <th scope="col" class="py-3 pl-6 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
                                 {{ __('Status') }}
                             </th>
@@ -55,9 +52,6 @@
                                     ? 'Q' . $version->ends_securityfixes_at->quarter . ' ' . $version->ends_securityfixes_at->year . ' (' . __('estimated') . ')'
                                     : $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat')) }}
                                 @endif
-                            </td>
-                            <td class="py-4 pl-6 text-sm text-gray-500 lg:pl-8 whitespace-nowrap">
-                                {{ $version->is_lts ? '✓' : '' }}
                             </td>
                             <td scope="col">
                                 <div class="{{ $statusClassMap[$version->status] }}">

--- a/resources/views/partials/tables/eol_table.blade.php
+++ b/resources/views/partials/tables/eol_table.blade.php
@@ -25,9 +25,6 @@
                                 {{ __('Security Fixes Until') }}
                             </th>
                             <th scope="col" class="py-3 pl-6 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
-                                {{ __('LTS?') }}
-                            </th>
-                            <th scope="col" class="py-3 pl-6 text-xs font-medium tracking-wider text-left text-gray-500 uppercase">
                                 {{ __('Status') }}
                             </th>
                         </tr>
@@ -63,9 +60,6 @@
                                             ? $version->ends_securityfixes_at->translatedFormat(__('DateLongFormat'))
                                             : ''
                                     }}
-                                </td>
-                                <td class="py-4 pl-6 text-sm text-gray-500 lg:pl-8 whitespace-nowrap">
-                                    {{ $version->is_lts ? '✓' : '' }}
                                 </td>
                                 <td scope="col">
                                     <div class="{{ $statusClassMap[$version->status] }}">

--- a/resources/views/partials/tables/show_table.blade.php
+++ b/resources/views/partials/tables/show_table.blade.php
@@ -15,9 +15,6 @@
                 {{ __('Security Fixes Until') }}
             </th>
             <th scope="col" class="py-3 pl-6 text-xs font-medium tracking-wider text-left text-gray-500 uppercase lg:pl-8">
-                {{ __('LTS?') }}
-            </th>
-            <th scope="col" class="py-3 pl-6 text-xs font-medium tracking-wider text-left text-gray-500 uppercase lg:pl-8">
                 {{ __('Status') }}
             </th>
             </tr>
@@ -79,9 +76,6 @@
                                 )
                                 : ''
                         }}
-                    </td>
-                    <td class="py-4 pl-6 text-sm text-gray-500 whitespace-nowrap">
-                        {{ $version->is_lts ? '✓' : '' }}
                     </td>
                     <td scope="col">
                         <div class="{{ $statusClassMap[$version->status] }}">

--- a/tests/Feature/ApiListVersionsTest.php
+++ b/tests/Feature/ApiListVersionsTest.php
@@ -85,9 +85,7 @@ class ApiListVersionsTest extends TestCase
             'ends_securityfixes_at' => $version->ends_securityfixes_at,
             'global' => [
                 'latest_version' => LaravelVersion::withoutGlobalScope('first')->latest('order')->first()->semver,
-                'latest_version_is_lts' => LaravelVersion::withoutGlobalScope('first')->latest('order')->first()->is_lts,
             ],
-            'is_lts' => $version->is_lts,
             'latest' => $version->last->semver,
             $version->major < 6 ? 'minor' : 'latest_minor' => $version->last->minor,
             'latest_patch' => $version->last->patch,

--- a/tests/Feature/ApiShowVersionTest.php
+++ b/tests/Feature/ApiShowVersionTest.php
@@ -39,7 +39,6 @@ class ApiShowVersionTest extends TestCase
         $this->getJson($older->api_url)
             ->assertJsonFragment([
                 'latest_version' => $newest->semver,
-                'latest_version_is_lts' => $newest->is_lts,
             ]);
     }
 }


### PR DESCRIPTION
This PR removes the concept of LTS (Long Term Stable) from the Laravel Versions UI and API.
The Laravel team is dropping LTS releases.

LTS is also mentioned in language files for the phrase "Update to the latest major or LTS release.".

- [ ] `lang/ar.json`
- [ ] `lang/bn.json`
- [ ] `lang/de.json`
- [ ] `lang/en.json`
- [ ] `lang/es.json`
- [ ] `lang/fa.json`
- [ ] `lang/fr.json`
- [ ] `lang/id.json`
- [ ] `lang/it.json`
- [ ] `lang/ja.json`
- [ ] `lang/lt.json`
- [ ] `lang/pl.json`
- [ ] `lang/pt_BR.json`
- [ ] `lang/ru.json`
- [ ] `lang/si.json`
- [ ] `lang/sw.json`
- [ ] `lang/uk.json`
- [ ] `lang/vi.json`
- [ ] `lang/zh_CN.json`