### PR TITLE
Generate GitHub workflows to check php versions

### DIFF
--- a/.github/workflows/check-laravel-10.*-php.yml
+++ b/.github/workflows/check-laravel-10.*-php.yml
@@ -1,0 +1,46 @@
+name: 10.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["10.*", "8.2"]
+        - ["10.*", "8.1"]
+        - ["10.*", "8.0"]
+        - ["10.*", "7.4"]
+        - ["10.*", "7.3"]
+        - ["10.*", "7.2"]
+        - ["10.*", "7.1"]
+        - ["10.*", "7.0"]
+        - ["10.*", "5.6"]
+        - ["10.*", "5.5"]
+        - ["10.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-10.*-php.yml
+++ b/.github/workflows/check-laravel-10.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.0.*-php.yml
+++ b/.github/workflows/check-laravel-5.0.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.0.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.0.*", "8.2"]
+        - ["5.0.*", "8.1"]
+        - ["5.0.*", "8.0"]
+        - ["5.0.*", "7.4"]
+        - ["5.0.*", "7.3"]
+        - ["5.0.*", "7.2"]
+        - ["5.0.*", "7.1"]
+        - ["5.0.*", "7.0"]
+        - ["5.0.*", "5.6"]
+        - ["5.0.*", "5.5"]
+        - ["5.0.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.0.*-php.yml
+++ b/.github/workflows/check-laravel-5.0.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.1.*-php.yml
+++ b/.github/workflows/check-laravel-5.1.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.1.*-php.yml
+++ b/.github/workflows/check-laravel-5.1.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.1.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.1.*", "8.2"]
+        - ["5.1.*", "8.1"]
+        - ["5.1.*", "8.0"]
+        - ["5.1.*", "7.4"]
+        - ["5.1.*", "7.3"]
+        - ["5.1.*", "7.2"]
+        - ["5.1.*", "7.1"]
+        - ["5.1.*", "7.0"]
+        - ["5.1.*", "5.6"]
+        - ["5.1.*", "5.5"]
+        - ["5.1.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.2.*-php.yml
+++ b/.github/workflows/check-laravel-5.2.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.2.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.2.*", "8.2"]
+        - ["5.2.*", "8.1"]
+        - ["5.2.*", "8.0"]
+        - ["5.2.*", "7.4"]
+        - ["5.2.*", "7.3"]
+        - ["5.2.*", "7.2"]
+        - ["5.2.*", "7.1"]
+        - ["5.2.*", "7.0"]
+        - ["5.2.*", "5.6"]
+        - ["5.2.*", "5.5"]
+        - ["5.2.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.2.*-php.yml
+++ b/.github/workflows/check-laravel-5.2.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.3.*-php.yml
+++ b/.github/workflows/check-laravel-5.3.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.3.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.3.*", "8.2"]
+        - ["5.3.*", "8.1"]
+        - ["5.3.*", "8.0"]
+        - ["5.3.*", "7.4"]
+        - ["5.3.*", "7.3"]
+        - ["5.3.*", "7.2"]
+        - ["5.3.*", "7.1"]
+        - ["5.3.*", "7.0"]
+        - ["5.3.*", "5.6"]
+        - ["5.3.*", "5.5"]
+        - ["5.3.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.3.*-php.yml
+++ b/.github/workflows/check-laravel-5.3.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.4.*-php.yml
+++ b/.github/workflows/check-laravel-5.4.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.4.*-php.yml
+++ b/.github/workflows/check-laravel-5.4.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.4.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.4.*", "8.2"]
+        - ["5.4.*", "8.1"]
+        - ["5.4.*", "8.0"]
+        - ["5.4.*", "7.4"]
+        - ["5.4.*", "7.3"]
+        - ["5.4.*", "7.2"]
+        - ["5.4.*", "7.1"]
+        - ["5.4.*", "7.0"]
+        - ["5.4.*", "5.6"]
+        - ["5.4.*", "5.5"]
+        - ["5.4.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.5.*-php.yml
+++ b/.github/workflows/check-laravel-5.5.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.5.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.5.*", "8.2"]
+        - ["5.5.*", "8.1"]
+        - ["5.5.*", "8.0"]
+        - ["5.5.*", "7.4"]
+        - ["5.5.*", "7.3"]
+        - ["5.5.*", "7.2"]
+        - ["5.5.*", "7.1"]
+        - ["5.5.*", "7.0"]
+        - ["5.5.*", "5.6"]
+        - ["5.5.*", "5.5"]
+        - ["5.5.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.5.*-php.yml
+++ b/.github/workflows/check-laravel-5.5.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.6.*-php.yml
+++ b/.github/workflows/check-laravel-5.6.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.6.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.6.*", "8.2"]
+        - ["5.6.*", "8.1"]
+        - ["5.6.*", "8.0"]
+        - ["5.6.*", "7.4"]
+        - ["5.6.*", "7.3"]
+        - ["5.6.*", "7.2"]
+        - ["5.6.*", "7.1"]
+        - ["5.6.*", "7.0"]
+        - ["5.6.*", "5.6"]
+        - ["5.6.*", "5.5"]
+        - ["5.6.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.6.*-php.yml
+++ b/.github/workflows/check-laravel-5.6.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.7.*-php.yml
+++ b/.github/workflows/check-laravel-5.7.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.7.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.7.*", "8.2"]
+        - ["5.7.*", "8.1"]
+        - ["5.7.*", "8.0"]
+        - ["5.7.*", "7.4"]
+        - ["5.7.*", "7.3"]
+        - ["5.7.*", "7.2"]
+        - ["5.7.*", "7.1"]
+        - ["5.7.*", "7.0"]
+        - ["5.7.*", "5.6"]
+        - ["5.7.*", "5.5"]
+        - ["5.7.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.7.*-php.yml
+++ b/.github/workflows/check-laravel-5.7.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-5.8.*-php.yml
+++ b/.github/workflows/check-laravel-5.8.*-php.yml
@@ -1,0 +1,46 @@
+name: 5.8.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["5.8.*", "8.2"]
+        - ["5.8.*", "8.1"]
+        - ["5.8.*", "8.0"]
+        - ["5.8.*", "7.4"]
+        - ["5.8.*", "7.3"]
+        - ["5.8.*", "7.2"]
+        - ["5.8.*", "7.1"]
+        - ["5.8.*", "7.0"]
+        - ["5.8.*", "5.6"]
+        - ["5.8.*", "5.5"]
+        - ["5.8.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-5.8.*-php.yml
+++ b/.github/workflows/check-laravel-5.8.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-6.*-php.yml
+++ b/.github/workflows/check-laravel-6.*-php.yml
@@ -1,0 +1,46 @@
+name: 6.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["6.*", "8.2"]
+        - ["6.*", "8.1"]
+        - ["6.*", "8.0"]
+        - ["6.*", "7.4"]
+        - ["6.*", "7.3"]
+        - ["6.*", "7.2"]
+        - ["6.*", "7.1"]
+        - ["6.*", "7.0"]
+        - ["6.*", "5.6"]
+        - ["6.*", "5.5"]
+        - ["6.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-6.*-php.yml
+++ b/.github/workflows/check-laravel-6.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-7.*-php.yml
+++ b/.github/workflows/check-laravel-7.*-php.yml
@@ -1,0 +1,46 @@
+name: 7.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["7.*", "8.2"]
+        - ["7.*", "8.1"]
+        - ["7.*", "8.0"]
+        - ["7.*", "7.4"]
+        - ["7.*", "7.3"]
+        - ["7.*", "7.2"]
+        - ["7.*", "7.1"]
+        - ["7.*", "7.0"]
+        - ["7.*", "5.6"]
+        - ["7.*", "5.5"]
+        - ["7.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-7.*-php.yml
+++ b/.github/workflows/check-laravel-7.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-8.*-php.yml
+++ b/.github/workflows/check-laravel-8.*-php.yml
@@ -1,0 +1,46 @@
+name: 8.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["8.*", "8.2"]
+        - ["8.*", "8.1"]
+        - ["8.*", "8.0"]
+        - ["8.*", "7.4"]
+        - ["8.*", "7.3"]
+        - ["8.*", "7.2"]
+        - ["8.*", "7.1"]
+        - ["8.*", "7.0"]
+        - ["8.*", "5.6"]
+        - ["8.*", "5.5"]
+        - ["8.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-8.*-php.yml
+++ b/.github/workflows/check-laravel-8.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/.github/workflows/check-laravel-9.*-php.yml
+++ b/.github/workflows/check-laravel-9.*-php.yml
@@ -1,0 +1,46 @@
+name: 9.* Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:
+        - ["9.*", "8.2"]
+        - ["9.*", "8.1"]
+        - ["9.*", "8.0"]
+        - ["9.*", "7.4"]
+        - ["9.*", "7.3"]
+        - ["9.*", "7.2"]
+        - ["9.*", "7.1"]
+        - ["9.*", "7.0"]
+        - ["9.*", "5.6"]
+        - ["9.*", "5.5"]
+        - ["9.*", "5.4"]
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/check-laravel-9.*-php.yml
+++ b/.github/workflows/check-laravel-9.*-php.yml
@@ -40,6 +40,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/app/Console/Commands/GenerateLaravelPhpChecks.php
+++ b/app/Console/Commands/GenerateLaravelPhpChecks.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+class GenerateLaravelPhpChecks extends Command
+{
+    protected $signature = 'github:workflows';
+
+    protected $description = 'Generate the Laravel PHP checks workflows.';
+
+    public function handle()
+    {
+        if (! is_dir(getcwd() . '/.github/workflows')) {
+            mkdir(getcwd() . '/.github/workflows', 0777, true);
+        }
+
+        $this->getMatrix()->filter(function (array $phpVersions, string $laravelVersion) {
+            return $this->generateWorkflow($laravelVersion, $phpVersions);
+        })->whenNotEmpty(
+            fn () => $this->output->success('Workflows (re)generated successfully.'),
+            fn () => $this->output->error('Generating workflows failed.')
+        );
+    }
+
+    private function getMatrix(): Collection
+    {
+        return collect([
+            '10.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '9.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '8.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '7.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '6.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.8.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.7.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.6.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.5.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.4.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.3.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.2.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.1.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+            '5.0.*' => ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
+        ]);
+    }
+
+    private function generateWorkflow(string $laravelVersion, array $phpVersions): bool
+    {
+        $workflow = $this->getWorkflowStub();
+        $workflow = str_replace('{{ LARAVEL_VERSION }}', $laravelVersion, $workflow);
+        $workflow = str_replace('{{ LARAVEL_MATRIX }}', $this->generateMatrix($laravelVersion, $phpVersions), $workflow);
+
+        $path = getcwd() . "/.github/workflows/check-laravel-{$laravelVersion}-php.yml";
+
+        return (bool) file_put_contents($path, $workflow);
+    }
+
+    private function getWorkflowStub(): string
+    {
+        return
+<<<'EOT'
+name: {{ LARAVEL_VERSION }} Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        laravel:{{ LARAVEL_MATRIX }}
+
+    name: Laravel ${{ matrix.laravel[0] }} | PHP ${{ matrix.laravel[1] }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: laravel-${{ matrix.laravel[0] }}-php-${{ matrix.laravel[1] }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.laravel[1] }}
+      - run: |
+          composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
+          cd laravel
+          composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer install
+          php -r "file_exists('.env') || copy('.env.example', '.env');"
+          php artisan key:generate --ansi
+          vendor/bin/phpunit
+
+EOT;
+    }
+
+    private function generateMatrix(string $laravelVersion, array $phpVersions): string
+    {
+        return "\n" . collect($phpVersions)->map(fn ($phpVersion) =>
+            "        - [\"{$laravelVersion}\", \"{$phpVersion}\"]"
+        )->implode("\n");
+    }
+}

--- a/app/Console/Commands/GenerateLaravelPhpChecks.php
+++ b/app/Console/Commands/GenerateLaravelPhpChecks.php
@@ -91,6 +91,7 @@ jobs:
           composer create-project --no-install --no-scripts laravel/laravel="${{ matrix.laravel[0] }}" laravel
           cd laravel
           composer config --no-interaction allow-plugins.kylekatarnls/update-helper true
+          composer config --no-interaction allow-plugins.symfony/thanks true
           composer install
           php -r "file_exists('.env') || copy('.env.example', '.env');"
           php artisan key:generate --ansi

--- a/app/Console/Commands/GenerateLaravelPhpChecks.php
+++ b/app/Console/Commands/GenerateLaravelPhpChecks.php
@@ -102,8 +102,7 @@ EOT;
 
     private function generateMatrix(string $laravelVersion, array $phpVersions): string
     {
-        return "\n" . collect($phpVersions)->map(fn ($phpVersion) =>
-            "        - [\"{$laravelVersion}\", \"{$phpVersion}\"]"
+        return "\n" . collect($phpVersions)->map(fn ($phpVersion) => "        - [\"{$laravelVersion}\", \"{$phpVersion}\"]"
         )->implode("\n");
     }
 }


### PR DESCRIPTION
This PR starts exploring how we might generate supported PHP versions. 
This relates to #20 

As suggested by @Gummibeer, I created a couple of workflows to test PHP support for Laravel versions. I tried this as a single file but found a limitation with the matrix (I think it was 256 jobs).  I also thought it might be nice to have a workflow for each item. Then, we could link to the workflow badge to show passing/failing. I decided against this due to the number of workflows needed (450+), and I wasn't sure how many or long they would be kept. 

The checks start at Laravel 5 and PHP 5.4 due to limitations with `composer create-project` and `shivammathur/setup-php` not being able to install earlier versions (although we could add Laravel 4.2). 

The checks are configured to allow them to be run manually and scheduled to run once a month.   Although, running these manually might be fine.

<img width="193" alt="Screenshot 2023-02-15 at 4 56 21 PM" src="https://user-images.githubusercontent.com/194221/219230385-68ed8546-8327-47e2-a2ae-df974988f961.png">
  
<img width="195" alt="Screenshot 2023-02-15 at 4 56 38 PM" src="https://user-images.githubusercontent.com/194221/219230400-29d840ec-8fb4-40df-9379-0c6678aa27e5.png">
