### PR TITLE
Fix language select

### DIFF
--- a/app/View/Components/LanguageSelector.php
+++ b/app/View/Components/LanguageSelector.php
@@ -16,7 +16,7 @@ class LanguageSelector extends Component
 
     public function __construct()
     {
-        $this->formatted_languages = collect(Config::get('localized-routes.supported-locales', []))->map(function ($lang) {
+        $this->formatted_languages = collect(Config::get('localized-routes.supported_locales', []))->map(function ($lang) {
             return [
                 'language_name' => $lang,
                 'language_name_native' => Config::get("localized-routes.locales-name-native.{$lang}", Str::upper($lang)),

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -15,7 +15,7 @@
     "Follow on Twitter for important dates": "Śledź ważne daty na Twitterze",
     "Future release": "Przyszłe wydanie",
     "Future releases": "Przyszłe wydania",
-    "Greetings from the author of the translations": "Tłumaczenie: Olsza (github.com/olsza || @czlowiek_it)",
+    "Greetings from the author of the translations": "Tłumaczenie: Olsza (github.com/olsza || www: olsza.czlowiek.it)",
     "Keep patch updated.": "Aktualizuj poprawki.",
     "Laravel News \"Laravel Releases\" page": "Laravel News \"Laravel Releases\"",
     "Laravel Version": "Wersja Laravel",

--- a/resources/views/partials/modules/header.blade.php
+++ b/resources/views/partials/modules/header.blade.php
@@ -1,7 +1,7 @@
 <header class="py-8 bg-gray-700">
     <div class="flex flex-col max-w-screen-xl px-4 mx-auto sm:items-center sm:justify-between sm:flex-row-reverse sm:px-6 lg:px-8">
 
-        @if (Config::has('localized-routes.supported-locales'))
+        @if (Config::has('localized-routes.supported_locales'))
             <x-language-selector />
         @endif
 


### PR DESCRIPTION
After PR #240, 'Upgrade to Laravel 11', the language selection box appears to be missing. The current PR addresses this issue.


After repair:
![image](https://github.com/user-attachments/assets/1a5d14fc-93b6-417c-893c-922f85ae394a)




Current status, before repairs:
![image](https://github.com/user-attachments/assets/9279a9ea-8123-44cb-8795-dfab28d29891)
