### PR TITLE
Laravel 12.55.1 Shift

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1242,16 +1242,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.55.0",
+            "version": "v12.55.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6917962a55ac91598e8c5e2ebd25e27aed121b5e"
+                "reference": "6d9185a248d101b07eecaf8fd60b18129545fd33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6917962a55ac91598e8c5e2ebd25e27aed121b5e",
-                "reference": "6917962a55ac91598e8c5e2ebd25e27aed121b5e",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/6d9185a248d101b07eecaf8fd60b18129545fd33",
+                "reference": "6d9185a248d101b07eecaf8fd60b18129545fd33",
                 "shasum": ""
             },
             "require": {
@@ -1460,7 +1460,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-17T14:19:00+00:00"
+            "time": "2026-03-18T14:28:59+00:00"
         },
         {
             "name": "laravel/prompts",
@@ -3698,31 +3698,31 @@
         },
         {
             "name": "silber/page-cache",
-            "version": "v1.1.1",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JosephSilber/page-cache.git",
-                "reference": "e58b995b8d2b0aff31981eae4fb263c7b5caf7b9"
+                "reference": "5202e88e0322cc991591450d951545adb8cbd92c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JosephSilber/page-cache/zipball/e58b995b8d2b0aff31981eae4fb263c7b5caf7b9",
-                "reference": "e58b995b8d2b0aff31981eae4fb263c7b5caf7b9",
+                "url": "https://api.github.com/repos/JosephSilber/page-cache/zipball/5202e88e0322cc991591450d951545adb8cbd92c",
+                "reference": "5202e88e0322cc991591450d951545adb8cbd92c",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^11.0|^12.0",
-                "illuminate/filesystem": "^11.0|^12.0",
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "illuminate/filesystem": "^11.0|^12.0|^13.0",
                 "php": "^8.2",
-                "symfony/http-foundation": "^7.0"
+                "symfony/http-foundation": "^7.0|^8.0"
             },
             "require-dev": {
-                "illuminate/container": "^11.0|^12.0",
+                "illuminate/container": "^11.0|^12.0|^13.0",
                 "laravel/pint": "^1.14",
                 "mockery/mockery": "^1.6.9",
-                "pestphp/pest": "^3.7",
-                "phpunit/phpunit": "^11.0",
-                "symfony/var-dumper": "^7.0"
+                "pestphp/pest": "^3.7|^4.0",
+                "phpunit/phpunit": "^11.0|^12.0",
+                "symfony/var-dumper": "^7.0|^8.0"
             },
             "suggest": {
                 "illuminate/console": "Allows clearing the cache via artisan"
@@ -3757,9 +3757,9 @@
             ],
             "support": {
                 "issues": "https://github.com/JosephSilber/page-cache/issues",
-                "source": "https://github.com/JosephSilber/page-cache/tree/v1.1.1"
+                "source": "https://github.com/JosephSilber/page-cache/tree/v1.1.2"
             },
-            "time": "2025-02-24T22:10:38+00:00"
+            "time": "2026-03-18T13:07:35+00:00"
         },
         {
             "name": "spatie/backtrace",


### PR DESCRIPTION
This pull request includes updates for the recent patch version release of Laravel as well as bumps your package dependencies. You may review the full list of changes in the [Laravel Release Notes](https://github.com/laravel/framework/releases/tag/v12.55.1).

**Before merging**, you need to:

- Checkout the `shift-ci-v12.55.1` branch
- Review **all** pull request comments for additional changes
- Run `composer update`
- Thoroughly test your application ([no tests?](https://laravelshift.com/laravel-test-generator), [no CI?](https://laravelshift.com/ci-generator))
